### PR TITLE
[Fix/42] 주변 아카이브 조회 반경 기본값 누락

### DIFF
--- a/apps/backend/api/src/main/java/com/feelarchive/api/archive/controller/request/NearbyArchiveRequest.java
+++ b/apps/backend/api/src/main/java/com/feelarchive/api/archive/controller/request/NearbyArchiveRequest.java
@@ -6,4 +6,11 @@ public record NearbyArchiveRequest(
     BigDecimal latitude,
     BigDecimal longitude,
     double radius
-) {}
+) {
+
+  public NearbyArchiveRequest {
+    if (radius <= 0.0 ) {
+      radius = 50.0;
+    }
+  }
+}


### PR DESCRIPTION
### 🔍 개요 (Summary)

- 주변 아카이브 조회 시 기획 의도(기본 반경 50m)를 반영하기 위한 로직 보완

### ✨ 변경 내용 (Changes)

- `NearbyArchiveRequest` (Record) 내 컴팩트 생성자 도입
- `radius <= 0.0`인 경우 기본값 50.0으로 할당하는 방어 로직 구현

### ✅ 테스트 (Testing)

- [x] http 파일을 통한 API 테스트 완료

### 🔄 관련 이슈 (Related Issues)

- Closes #42 

### ⚠️ 기타 참고 사항 (Notes)

- ...
