### PR TITLE
[Fix/51] 타임캡슐 조회 시 위치 정보 NPE 처리

### DIFF
--- a/apps/backend/api/src/main/java/com/feelarchive/api/timeCapsule/controller/response/TimeCapsuleSummaryResponse.java
+++ b/apps/backend/api/src/main/java/com/feelarchive/api/timeCapsule/controller/response/TimeCapsuleSummaryResponse.java
@@ -1,5 +1,6 @@
 package com.feelarchive.api.timeCapsule.controller.response;
 
+import com.feelarchive.api.common.response.LocationDetail;
 import com.feelarchive.domain.capsule.entity.CapsuleStatus;
 import com.feelarchive.domain.emotion.entity.Emotion;
 
@@ -7,7 +8,7 @@ public record TimeCapsuleSummaryResponse(
     Long id,
     Emotion emotion,
     String contentPreview,
-    String address,
+    LocationDetail location,
     CapsuleStatus status,
     String openAt,
     String createdAt

--- a/apps/backend/api/src/main/java/com/feelarchive/api/timeCapsule/service/TimeCapsuleMapper.java
+++ b/apps/backend/api/src/main/java/com/feelarchive/api/timeCapsule/service/TimeCapsuleMapper.java
@@ -1,10 +1,10 @@
 package com.feelarchive.api.timeCapsule.service;
 
+import com.feelarchive.api.common.response.LocationDetail;
 import com.feelarchive.api.timeCapsule.controller.request.TimeCapsuleRequest;
 import com.feelarchive.api.timeCapsule.controller.response.TimeCapsuleDetailResponse;
 import com.feelarchive.api.timeCapsule.controller.response.TimeCapsuleImageResponse;
 import com.feelarchive.api.timeCapsule.controller.response.TimeCapsuleSummaryResponse;
-import com.feelarchive.api.common.response.LocationDetail;
 import com.feelarchive.domain.archive.entity.vo.Location;
 import com.feelarchive.domain.capsule.entity.CapsuleStatus;
 import com.feelarchive.domain.capsule.entity.TimeCapsule;
@@ -28,13 +28,15 @@ public interface TimeCapsuleMapper {
         capsule.getId(),
         isVisible ? capsule.getEmotion() : null,
         isVisible ? summaryContent(capsule.getContent()) : null,
-        isVisible ? capsule.getLocation().getLocationLabel() : null,
+        isVisible ? convertLocation(capsule.getLocation()) : null,
         capsule.getCapsuleStatus(),
         formatDate(capsule.getOpenAt()),
         formatDate(capsule.getCreatedAt())
     );
   }
-  default TimeCapsuleDetailResponse toDetail(TimeCapsule capsule, List<TimeCapsuleImageResponse> images) {
+
+  default TimeCapsuleDetailResponse toDetail(TimeCapsule capsule,
+      List<TimeCapsuleImageResponse> images) {
     boolean isVisible = isTimeCapsuleVisible(capsule);
 
     return new TimeCapsuleDetailResponse(
@@ -46,7 +48,7 @@ public interface TimeCapsuleMapper {
         capsule.getCapsuleStatus(),
         formatDate(capsule.getOpenAt()),
         formatDate(capsule.getCreatedAt())
-        );
+    );
   }
 
 
@@ -55,6 +57,7 @@ public interface TimeCapsuleMapper {
   }
 
   private LocationDetail convertLocation(Location location) {
+    if (location == null) return null;
     return new LocationDetail(location.getLocationLabel(), location.getLatitude(), location.getLongitude());
   }
 
@@ -66,6 +69,6 @@ public interface TimeCapsuleMapper {
     if (Objects.isNull(dateTime)) {
       return null;
     }
-    return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+    return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm"));
   }
 }


### PR DESCRIPTION
### 🔍 개요 (Summary)

- 타임캡슐 조회 시 위치 정보가 없을 때 발행사던 NPE 예외를 처리
- 타임캡슐 조회 시 시간 포맷에 시분 추가

### ✨ 변경 내용 (Changes)

- 타임캡술 조회 시 Mapper 로직에 NPE 처리 로직 추가
    - TimeCapsuleMapper 내 convertLocation 메서드에 NPE 처리 로직 적용 후 활용
- 타임캡슐 조회 시 시간 포맷에 시분 추가 `yyyy.MM.dd HH:mm`

### ✅ 테스트 (Testing)

- [x] http 파일을 통한 API 테스트 완료

### 🔄 관련 이슈 (Related Issues)

- Closes #51 

### ⚠️ 기타 참고 사항 (Notes)

- ...
