### PR TITLE
[Fix79] FileController 분리 및 api 모듈로 이동

### DIFF
--- a/apps/backend/api/src/main/java/com/feelarchive/api/RestApiApplication.java
+++ b/apps/backend/api/src/main/java/com/feelarchive/api/RestApiApplication.java
@@ -1,8 +1,8 @@
 package com.feelarchive.api;
 
-import com.feelarchive.api.common.file.FileProperties;
 import com.feelarchive.api.config.auth.CookieProperties;
 import com.feelarchive.api.config.auth.TokenProperties;
+import com.feelarchive.api.file.service.FileProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/apps/backend/api/src/main/java/com/feelarchive/api/archive/service/ArchiveImageService.java
+++ b/apps/backend/api/src/main/java/com/feelarchive/api/archive/service/ArchiveImageService.java
@@ -8,7 +8,7 @@ import static com.feelarchive.domain.file.exception.FileExceptionCode.FILE_NOT_R
 
 import com.feelarchive.api.archive.controller.response.ArchiveImageDownloadResponse;
 import com.feelarchive.api.archive.controller.response.ArchiveImageResponse;
-import com.feelarchive.api.common.file.FileService;
+import com.feelarchive.api.file.service.FileService;
 import com.feelarchive.common.excepion.FeelArchiveException;
 import com.feelarchive.domain.archive.entity.Archive;
 import com.feelarchive.domain.archive.entity.ArchiveImage;

--- a/apps/backend/api/src/main/java/com/feelarchive/api/file/controller/FileController.java
+++ b/apps/backend/api/src/main/java/com/feelarchive/api/file/controller/FileController.java
@@ -1,23 +1,15 @@
-package com.feelarchive.api.common.file;
+package com.feelarchive.api.file.controller;
 
-import com.feelarchive.api.archive.controller.response.ArchiveImageDownloadResponse;
 import com.feelarchive.api.archive.controller.response.ArchiveImageResponse;
 import com.feelarchive.api.archive.service.ArchiveImageService;
-import com.feelarchive.api.timeCapsule.controller.response.TimeCapsuleImageDownloadResponse;
 import com.feelarchive.api.timeCapsule.controller.response.TimeCapsuleImageResponse;
 import com.feelarchive.api.timeCapsule.service.TimeCapsuleImageService;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Profile;
-import org.springframework.core.io.Resource;
-import org.springframework.http.ContentDisposition;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,11 +17,10 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-@Profile("local")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1")
-public class LocalFileController {
+public class FileController {
 
   private final ArchiveImageService archiveImageService;
   private final TimeCapsuleImageService timeCapsuleImageService;
@@ -43,26 +34,6 @@ public class LocalFileController {
     List<ArchiveImageResponse> responses = archiveImageService.uploads(id, userId, images);
     return ResponseEntity.ok().body(responses);
   }
-
-  @GetMapping("/archives/{archiveId}/{fileName}")
-  public ResponseEntity<Resource> downloadArchiveImages(
-      @AuthenticationPrincipal Long userId,
-      @PathVariable Long archiveId,
-      @PathVariable String fileName)
-  {
-    ArchiveImageDownloadResponse response = archiveImageService.download(archiveId, fileName, userId);
-
-    ContentDisposition contentDisposition = ContentDisposition.builder("inline")
-        .filename(response.getFileMeta().getOriginalName(), StandardCharsets.UTF_8)
-        .build();
-
-    return ResponseEntity.ok()
-        .contentType(MediaType.parseMediaType(response.getFileMeta().getContentType()))
-        .contentLength(response.getFileMeta().getSizeBytes())
-        .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString())
-        .body(response.getResource());
-  }
-
 
   @DeleteMapping("/archives/{archiveId}/images/{imageId}")
   public ResponseEntity<Void> deleteArchiveImages(
@@ -93,24 +64,4 @@ public class LocalFileController {
     timeCapsuleImageService.delete(timeCapsuleId, imageId, userId);
     return ResponseEntity.noContent().build();
   }
-
-  @GetMapping("/time-capsule/{timeCapsuleId}/{fileName}")
-  public ResponseEntity<Resource> downloadTimeCapsuleImages(
-      @AuthenticationPrincipal Long userId,
-      @PathVariable Long timeCapsuleId,
-      @PathVariable String fileName)
-  {
-    TimeCapsuleImageDownloadResponse response = timeCapsuleImageService.download(timeCapsuleId, fileName, userId);
-
-    ContentDisposition contentDisposition = ContentDisposition.builder("inline")
-        .filename(response.fileMeta().getOriginalName(), StandardCharsets.UTF_8)
-        .build();
-
-    return ResponseEntity.ok()
-        .contentType(MediaType.parseMediaType(response.fileMeta().getContentType()))
-        .contentLength(response.fileMeta().getSizeBytes())
-        .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString())
-        .body(response.resource());
-  }
-
 }

--- a/apps/backend/api/src/main/java/com/feelarchive/api/file/controller/LocalFileController.java
+++ b/apps/backend/api/src/main/java/com/feelarchive/api/file/controller/LocalFileController.java
@@ -1,0 +1,67 @@
+package com.feelarchive.api.file.controller;
+
+import com.feelarchive.api.archive.controller.response.ArchiveImageDownloadResponse;
+import com.feelarchive.api.archive.service.ArchiveImageService;
+import com.feelarchive.api.timeCapsule.controller.response.TimeCapsuleImageDownloadResponse;
+import com.feelarchive.api.timeCapsule.service.TimeCapsuleImageService;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("local")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1")
+public class LocalFileController {
+
+  private final ArchiveImageService archiveImageService;
+  private final TimeCapsuleImageService timeCapsuleImageService;
+
+  @GetMapping("/archives/{archiveId}/{fileName}")
+  public ResponseEntity<Resource> downloadArchiveImages(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long archiveId,
+      @PathVariable String fileName)
+  {
+    ArchiveImageDownloadResponse response = archiveImageService.download(archiveId, fileName, userId);
+
+    ContentDisposition contentDisposition = ContentDisposition.builder("inline")
+        .filename(response.getFileMeta().getOriginalName(), StandardCharsets.UTF_8)
+        .build();
+
+    return ResponseEntity.ok()
+        .contentType(MediaType.parseMediaType(response.getFileMeta().getContentType()))
+        .contentLength(response.getFileMeta().getSizeBytes())
+        .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString())
+        .body(response.getResource());
+  }
+
+  @GetMapping("/time-capsule/{timeCapsuleId}/{fileName}")
+  public ResponseEntity<Resource> downloadTimeCapsuleImages(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long timeCapsuleId,
+      @PathVariable String fileName)
+  {
+    TimeCapsuleImageDownloadResponse response = timeCapsuleImageService.download(timeCapsuleId, fileName, userId);
+
+    ContentDisposition contentDisposition = ContentDisposition.builder("inline")
+        .filename(response.fileMeta().getOriginalName(), StandardCharsets.UTF_8)
+        .build();
+
+    return ResponseEntity.ok()
+        .contentType(MediaType.parseMediaType(response.fileMeta().getContentType()))
+        .contentLength(response.fileMeta().getSizeBytes())
+        .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString())
+        .body(response.resource());
+  }
+}

--- a/apps/backend/api/src/main/java/com/feelarchive/api/file/service/FileProperties.java
+++ b/apps/backend/api/src/main/java/com/feelarchive/api/file/service/FileProperties.java
@@ -1,4 +1,4 @@
-package com.feelarchive.api.common.file;
+package com.feelarchive.api.file.service;
 
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/apps/backend/api/src/main/java/com/feelarchive/api/file/service/FileService.java
+++ b/apps/backend/api/src/main/java/com/feelarchive/api/file/service/FileService.java
@@ -1,4 +1,4 @@
-package com.feelarchive.api.common.file;
+package com.feelarchive.api.file.service;
 
 import com.feelarchive.domain.file.entity.FileMeta;
 import java.nio.file.Path;

--- a/apps/backend/api/src/main/java/com/feelarchive/api/file/service/LocalFileService.java
+++ b/apps/backend/api/src/main/java/com/feelarchive/api/file/service/LocalFileService.java
@@ -1,4 +1,4 @@
-package com.feelarchive.api.common.file;
+package com.feelarchive.api.file.service;
 
 
 import static com.feelarchive.domain.file.exception.FileExceptionCode.DELETE_FAILED;

--- a/apps/backend/api/src/main/java/com/feelarchive/api/file/service/S3FileService.java
+++ b/apps/backend/api/src/main/java/com/feelarchive/api/file/service/S3FileService.java
@@ -1,4 +1,4 @@
-package com.feelarchive.api.common.file;
+package com.feelarchive.api.file.service;
 
 import com.feelarchive.common.excepion.FeelArchiveException;
 import com.feelarchive.domain.file.entity.FileMeta;

--- a/apps/backend/api/src/main/java/com/feelarchive/api/timeCapsule/service/TimeCapsuleImageService.java
+++ b/apps/backend/api/src/main/java/com/feelarchive/api/timeCapsule/service/TimeCapsuleImageService.java
@@ -6,7 +6,7 @@ import static com.feelarchive.domain.capsule.exception.TimeCapsuleExceptionCode.
 import static com.feelarchive.domain.file.exception.FileExceptionCode.FILE_NOT_FOUND;
 import static com.feelarchive.domain.file.exception.FileExceptionCode.FILE_NOT_READABLE;
 
-import com.feelarchive.api.common.file.FileService;
+import com.feelarchive.api.file.service.FileService;
 import com.feelarchive.api.timeCapsule.controller.response.TimeCapsuleImageDownloadResponse;
 import com.feelarchive.api.timeCapsule.controller.response.TimeCapsuleImageResponse;
 import com.feelarchive.common.excepion.FeelArchiveException;


### PR DESCRIPTION
### 🔍 개요
prod 환경에서 이미지 업로드 불가 버그 수정 및 파일 컨트롤러 구조 개선

### ✨ 변경 내용
- FileController 신규 생성 (업로드/삭제, 프로필 무관)
- LocalFileController는 다운로드 API만 유지 (@Profile("local"))
- common/file → api/file 모듈 이동

### ✅ 테스트
- [x] 로컬에서 이미지 업로드/삭제 테스트 완료

### 🔄 관련 이슈
- Closes #79 

### ⚠️ 기타 참고 사항
- ...